### PR TITLE
Argument consistency and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,34 +112,47 @@ There are two key ways to run `pg-upsert` from the command line: using a configu
 Running `pg-upsert --help` will display the following help message:
 
 ```txt
- Usage: pg-upsert [OPTIONS]
+Usage: pg-upsert [OPTIONS]
 
- Run not-NULL, Primary Key, Foreign Key, and Check Constraint checks on staging tables then update and insert (upsert) data from staging tables to base tables.
+Run not-NULL, Primary Key, Foreign Key, and Check Constraint checks on staging tables then update and insert (upsert) data from staging tables to base tables.
 
-╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --version          -v               Display the version and exit                                                   │
-│ --debug                             Display debug output                                                           │
-│ --docs                              Open the documentation in a web browser                                        │
-│ --quiet            -q               Suppress all console output                                                    │
-│ --logfile          -l      PATH     Write log messages to a log file [default: None]                               │
-│ --exclude-columns  -x      TEXT     Comma-separated list of columns to exclude from null checks [default: None]    │
-│ --null-columns     -n      TEXT     Comma-separated list of columns to exclude from null checks [default: None]    │
-│ --commit           -c               Commit changes to database                                                     │
-│ --interactive      -i               Display interactive GUI of important table information                         │
-│ --upsert-method    -m      TEXT     Method to use for upsert (upsert, update, insert) [default: upsert]            │
-│ --host             -h      TEXT     Database host [default: None]                                                  │
-│ --port             -p      INTEGER  Database port [default: 5432]                                                  │
-│ --database         -d      TEXT     Database name [default: None]                                                  │
-│ --user             -u      TEXT     Database user [default: None]                                                  │
-│ --staging-schema   -s      TEXT     Staging schema name [default: staging]                                         │
-│ --base-schema      -b      TEXT     Base schema name [default: public]                                             │
-│ --encoding         -e      TEXT     Encoding of the database [default: utf-8]                                      │
-│ --config-file      -f      PATH     Path to configuration YAML file [default: None]                                │
-│ --tables           -t      TEXT     Table name(s) [default: None]                                                  │
-│ --generate-config  -g               Generate a template configuration file. If any other options are               │
-│                                     provided, they will be included in the generated file.                         │
-│ --help                              Show this message and exit.                                                    │
-╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ─────────────────────────────────────────────────────────────────────────────────────────╮
+│ --version          -v               Display the version and exit.                                 │
+│ --debug                             Display debug output.                                         │
+│ --docs                              Open the documentation in a web browser.                      │
+│ --quiet            -q               Suppress all console output.                                  │
+│ --logfile          -l      PATH     Write log messages to a log file. [default: None]             │
+│ --exclude-columns  -x      TEXT     List of column names to exclude from the upsert process.      │
+│                                     These columns will not be updated or inserted, but will       │
+│                                     still be checked during the QA process. [default: None]       │
+│ --null-columns     -n      TEXT     List of column names to exclude from the not-null check       │
+│                                     during the QA process. Useful for auto-generated timestamps   │
+│                                     or serial columns, which may not be populated immediately.    │
+│                                     [default: None]                                               │
+│ --commit           -c               If True, changes will be committed to the database once the   │
+│                                     upsert process completes. If False, changes will be rolled    │
+│                                     back.                                                         │
+│ --interactive      -i               If True, the user will be prompted to confirm steps during    │
+│                                     the upsert process. If False, the process runs automatically. │
+│ --upsert-method    -m      TEXT     The method for upserting data. Must be 'upsert', 'update',    │
+│                                     or 'insert'. [default: upsert]                                │
+│ --host             -h      TEXT     Database host. [default: None]                                │
+│ --port             -p      INTEGER  Database port. [default: 5432]                                │
+│ --database         -d      TEXT     Database name. [default: None]                                │
+│ --user             -u      TEXT     Database user. [default: None]                                │
+│ --staging-schema   -s      TEXT     Name of the staging schema for QA checks and upserts.         │
+│                                     Tables here must match names in the base schema.              │
+│                                     [default: staging]                                            │
+│ --base-schema      -b      TEXT     Name of the base schema where tables are updated or inserted. │
+│                                     [default: public]                                             │
+│ --encoding         -e      TEXT     The encoding for the database connection. [default: utf-8]    │
+│ --config-file      -f      PATH     Path to configuration YAML file. [default: None]              │
+│ --tables           -t      TEXT     Table names to perform QA checks on and upsert.               │
+│                                     [default: None]                                               │
+│ --generate-config  -g               Generate a template configuration file. Includes provided     │
+│                                     options in the generated file.                                │
+│ --help                              Show this message and exit.                                   │
+╰───────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 An example of running `pg-upsert` from the command line is shown below:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,25 +17,25 @@ Initialize a PostgreSQL database called `dev` with the following schema and data
 Create a Python script called `upsert_data.py` that calls [PgUpsert](./pg_upsert.md#pgupsert) to upsert data from staging tables to base tables.
 
    ```python
-    import logging
+   import logging
 
-    from pg_upsert import PgUpsert
+   from pg_upsert import PgUpsert
 
-    logger = logging.getLogger("pg_upsert")
-    logger.setLevel(logging.INFO)
-    logger.addHandler(logging.StreamHandler())
+   logger = logging.getLogger("pg_upsert")
+   logger.setLevel(logging.INFO)
+   logger.addHandler(logging.StreamHandler())
 
-    PgUpsert(
-        uri="postgresql://user@localhost:5432/dev", # Note the missing password. pg_upsert will prompt for the password.
-        tables=("genres", "publishers", "books", "authors", "book_authors"),
-        stg_schema="staging",
-        base_schema="public",
-        do_commit=True,
-        upsert_method="upsert",
-        interactive=False,
+   PgUpsert(
+       uri="postgresql://user@localhost:5432/dev", # Note the missing password. pg_upsert will prompt for the password.
+       tables=("genres", "publishers", "books", "authors", "book_authors"),
+       staging_schema="staging",
+       base_schema="public",
+       do_commit=True,
+       upsert_method="upsert",
+       interactive=False,
        exclude_cols=("rev_user", "rev_time"),
        exclude_null_check_cols=("book_alias"),
-    ).run()
+   ).run()
    ```
 
 ### 3 - Run the script

--- a/src/pg_upsert/cli.py
+++ b/src/pg_upsert/cli.py
@@ -30,21 +30,21 @@ def cli(
         typer.Option(
             "--version",
             "-v",
-            help="Display the version and exit",
+            help="Display the version and exit.",
         ),
     ] = False,
     debug: Annotated[
         bool,
         typer.Option(
             "--debug",
-            help="Display debug output",
+            help="Display debug output.",
         ),
     ] = False,
     docs: Annotated[
         bool,
         typer.Option(
             "--docs",
-            help="Open the documentation in a web browser",
+            help="Open the documentation in a web browser.",
         ),
     ] = False,
     quiet: Annotated[
@@ -52,7 +52,7 @@ def cli(
         typer.Option(
             "--quiet",
             "-q",
-            help="Suppress all console output",
+            help="Suppress all console output.",
         ),
     ] = False,
     logfile: Annotated[
@@ -60,7 +60,7 @@ def cli(
         typer.Option(
             "-l",
             "--logfile",
-            help="Write log messages to a log file",
+            help="Write log messages to a log file.",
         ),
     ] = None,
     exclude_columns: Annotated[
@@ -68,7 +68,7 @@ def cli(
         typer.Option(
             "--exclude-columns",
             "-x",
-            help="Comma-separated list of columns to exclude from null checks",
+            help="List of column names to exclude from the upsert process. These columns will not be updated or inserted to, however, they will still be checked during the QA process.",  # noqa
         ),
     ] = None,
     null_columns: Annotated[
@@ -76,7 +76,7 @@ def cli(
         typer.Option(
             "--null-columns",
             "-n",
-            help="Comma-separated list of columns to exclude from null checks",
+            help="List of column names to exclude from the not-null check during the QA process. You may wish to exclude certain columns from null checks, such as auto-generated timestamps or serial columns as they may not be populated until after records are inserted or updated.",  # noqa
         ),
     ] = None,
     commit: Annotated[
@@ -84,7 +84,7 @@ def cli(
         typer.Option(
             "--commit",
             "-c",
-            help="Commit changes to database",
+            help="If True, changes will be committed to the database once the upsert process has completed successfully. If False, changes will be rolled back.",  # noqa
         ),
     ] = False,
     interactive: Annotated[
@@ -92,7 +92,7 @@ def cli(
         typer.Option(
             "--interactive",
             "-i",
-            help="Display interactive GUI of important table information",
+            help="If True, the user will be prompted with multiple dialogs to confirm various steps during the upsert process. If False, the upsert process will run without user intervention.",  # noqa
         ),
     ] = False,
     upsert_method: Annotated[
@@ -100,7 +100,7 @@ def cli(
         typer.Option(
             "--upsert-method",
             "-m",
-            help="Method to use for upsert (upsert, update, insert)",
+            help="The method to use for upserting data. Must be one of 'upsert', 'update', or 'insert'.",
         ),
     ] = "upsert",
     host: Annotated[
@@ -108,7 +108,7 @@ def cli(
         typer.Option(
             "--host",
             "-h",
-            help="Database host",
+            help="Database host.",
         ),
     ] = None,
     port: Annotated[
@@ -116,7 +116,7 @@ def cli(
         typer.Option(
             "--port",
             "-p",
-            help="Database port",
+            help="Database port.",
         ),
     ] = 5432,
     database: Annotated[
@@ -124,7 +124,7 @@ def cli(
         typer.Option(
             "--database",
             "-d",
-            help="Database name",
+            help="Database name.",
         ),
     ] = None,
     user: Annotated[
@@ -132,7 +132,7 @@ def cli(
         typer.Option(
             "--user",
             "-u",
-            help="Database user",
+            help="Database user.",
         ),
     ] = None,
     staging_schema: Annotated[
@@ -140,7 +140,7 @@ def cli(
         typer.Option(
             "--staging-schema",
             "-s",
-            help="Staging schema name",
+            help="Name of the staging schema where tables are located which will be used for QA checks and upserts. Tables in the staging schema must have the same name as the tables in the base schema that they will be upserted to.",  # noqa
         ),
     ] = "staging",
     base_schema: Annotated[
@@ -148,7 +148,7 @@ def cli(
         typer.Option(
             "--base-schema",
             "-b",
-            help="Base schema name",
+            help="Name of the base schema where tables are located which will be updated or inserted into.",
         ),
     ] = "public",
     encoding: Annotated[
@@ -156,7 +156,7 @@ def cli(
         typer.Option(
             "--encoding",
             "-e",
-            help="Encoding of the database",
+            help="The encoding to use for the database connection.",
         ),
     ] = "utf-8",
     config_file: Annotated[
@@ -173,7 +173,7 @@ def cli(
         typer.Option(
             "--tables",
             "-t",
-            help="Table name(s)",
+            help="Table names to perform QA checks on and upsert.",
         ),
     ] = None,
     generate_config: Annotated[
@@ -297,7 +297,7 @@ def cli(
             uri=f"postgresql://{args.user}@{args.host}:{args.port}/{args.database}",
             encoding="utf-8",
             tables=args.tables,
-            stg_schema=args.staging_schema,
+            staging_schema=args.staging_schema,
             base_schema=args.base_schema,
             do_commit=args.commit,
             upsert_method=args.upsert_method,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def ups(global_variables, db):
     yield PgUpsert(
         conn=db.conn,
         tables=("genres", "books", "authors", "book_authors", "publishers"),
-        stg_schema="staging",
+        staging_schema="staging",
         base_schema="public",
         do_commit=False,
         interactive=False,

--- a/tests/test_upsert.py
+++ b/tests/test_upsert.py
@@ -13,7 +13,7 @@ load_dotenv()
 def test_pgupsert_init(ups):
     """Test the PgUpsert object was initialized with the correct values."""
     assert ups.tables == ("genres", "books", "authors", "book_authors", "publishers")
-    assert ups.stg_schema == "staging"
+    assert ups.staging_schema == "staging"
     assert ups.base_schema == "public"
     assert ups.do_commit is False
     assert ups.interactive is False
@@ -84,10 +84,10 @@ def test_pgupsert_upsert_methods(ups):
 def test_pgupsert_validate_schemas(ups):
     """Test the validate_schemas function."""
     assert ups._validate_schemas() is None
-    ups.stg_schema = "staging2"
+    ups.staging_schema = "staging2"
     with pytest.raises(ValueError):
         ups._validate_schemas()
-    ups.stg_schema = "staging"
+    ups.staging_schema = "staging"
     ups.base_schema = "public2"
     with pytest.raises(ValueError):
         ups._validate_schemas()
@@ -321,7 +321,7 @@ def test_pgupsert_upsert_one_upsert(ups):
     assert row[1] == 20
 
 
-def test_pgupsert_upsert_no_commit_do_commit_false(ups):
+def test_pgupsert_upsert_no_commit_commit_false(ups):
     """Test that a successful upsert_one call does not commit the
     transaction unless the do_commit attribute is True and no errors are present.
     """
@@ -331,9 +331,9 @@ def test_pgupsert_upsert_no_commit_do_commit_false(ups):
     assert curs.fetchone()[0] == 0
 
 
-def test_pgupsert_upsert_do_commit_true(ups):
+def test_pgupsert_upsert_commit_true(ups):
     """Test that a successful upsert_one call does not commit the
-    transaction unless the do_commit attribute is True and no errors are present.
+    transaction unless the commit attribute is True and no errors are present.
     """
     ups.do_commit = True
     ups.upsert_one("genres").commit()


### PR DESCRIPTION
Rename `stg_schema` to `staging_schema` for consistency & sync CLI argument descriptions with the help text.

Documentation and help message updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R155): Updated the help message options to provide more detailed descriptions for each option.
* [`docs/examples.md`](diffhunk://#diff-42c9e8de9b02b38190aa003b14db6be144d9d6f34b266cf401330e9e62a3bba9L31-R31): Corrected the parameter name from `stg_schema` to `staging_schema` in the example script.

Code updates for consistency and clarity:

* [`src/pg_upsert/cli.py`](diffhunk://#diff-ca7b5cb63afc2c8924946de92ae3a5a22251ae213cbdb17f37df6a15b9b9a364L33-R159): Updated the help messages for various CLI options to be more descriptive and consistent. [[1]](diffhunk://#diff-ca7b5cb63afc2c8924946de92ae3a5a22251ae213cbdb17f37df6a15b9b9a364L33-R159) [[2]](diffhunk://#diff-ca7b5cb63afc2c8924946de92ae3a5a22251ae213cbdb17f37df6a15b9b9a364L176-R176) [[3]](diffhunk://#diff-ca7b5cb63afc2c8924946de92ae3a5a22251ae213cbdb17f37df6a15b9b9a364L300-R300)
* [`src/pg_upsert/upsert.py`](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L42-R44): Renamed the parameter `stg_schema` to `staging_schema` throughout the file for consistency and updated related docstrings and validation messages. [[1]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L42-R44) [[2]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L59-R59) [[3]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L77-R77) [[4]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L90-R101) [[5]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L110-R110) [[6]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L134-R134) [[7]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L154-R154) [[8]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L171-R171) [[9]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L182-R182) [[10]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L199-R199) [[11]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L214-R214) [[12]](diffhunk://#diff-839b9a4193070d9002cd6d80c3bf931847314948da78e8759bdd34b165a1b752L226-R226)