### PR TITLE
Support pytest 9.1 and remove pytest<9.1 pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ ______________________________________________________________________
 
 - **Migrated the database driver from psycopg2 to psycopg (psycopg 3).** The dependency changed from `psycopg2-binary>=2.9,<3` to `psycopg[binary]>=3.1,<4`. Internally, `PostgresDB` now uses psycopg 3 APIs (`psycopg.connect`, `conn.info.dsn`, `conn.info.get_parameters()`, `conn.autocommit`, and a `SET client_encoding` statement in place of `set_client_encoding`). **Breaking for callers using the `conn=` parameter:** a connection passed to `PgUpsert(conn=...)` / `PostgresDB(conn=...)` must now be a psycopg 3 connection (`psycopg.connect(...)`) rather than a psycopg2 connection. The public API (constructor, `qa_all()/upsert_all()/run()/commit()`, `qa_passed`, return values) is otherwise unchanged.
 
+### Fixed
+
+- **`CustomLogFormatter` no longer mutates the shared log record.** The debug log formatter rewrote `record.lineno` (to a padded string), `record.name`, and `record.levelname` in place. Because Python's logging passes the same record object to every handler, this corrupted formatting for any other handler on the chain — e.g. a configured logfile handler or an outer capture handler could receive a non-integer `lineno` and ANSI color codes. The formatter now works on a copy, leaving the original record intact.
+
 ______________________________________________________________________
 
 ## [1.22.1] - 2026-05-26

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,7 @@ dev = [
     "bump-my-version",
     "mkdocstrings-python",
     "pre-commit",
-    # Stopgap: pytest 9.1 changed capture/fd handling and breaks typer's
-    # CliRunner stream capture (test_cli.py -> "I/O operation on closed file",
-    # which cascades into test_export). Proper fix tracked in a follow-up PR.
-    "pytest<9.1",
+    "pytest",
     "pytest-cov",
     "python-dotenv",
     "ruff",

--- a/src/pg_upsert/utils.py
+++ b/src/pg_upsert/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from datetime import datetime
 from typing import ClassVar
@@ -23,6 +24,11 @@ class CustomLogFormatter(logging.Formatter):
 
     def format(self: CustomLogFormatter, record: logging.LogRecord) -> str:
         self.datefmt = "%Y-%m-%d %H:%M:%S"
+        # Work on a shallow copy: logging passes the same record object to
+        # every handler, so mutating it here (e.g. coercing lineno to a padded
+        # string) would corrupt formatting for other handlers on the chain
+        # (such as a file handler or pytest's log-capture handler).
+        record = copy.copy(record)
         self.asctime = self.formatTime(record, self.datefmt)
         record.name = f"{record.name:<20}"
         record.lineno = f"{record.lineno!s:<5}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,36 @@ import pg_upsert
 from pg_upsert import __version__
 from pg_upsert.cli import app
 
-runner = CliRunner()
+
+class _CliRunner(CliRunner):
+    """``CliRunner`` that disables pytest's capture during ``invoke``.
+
+    Typer/click's ``CliRunner`` does its own stdout/stderr capture (tests read
+    ``result.stdout``/``result.output``).  Under pytest>=9.1 pytest's capture
+    conflicts with that nested redirection and the runner's buffer is closed
+    before it can be read ("I/O operation on closed file").  Disabling pytest
+    capture only for the duration of the invocation — the same mechanism as
+    ``capsys.disabled()`` — avoids the conflict without pinning pytest.
+    """
+
+    capmanager = None
+
+    def invoke(self, *args, **kwargs):
+        if self.capmanager is not None:
+            with self.capmanager.global_and_fixture_disabled():
+                return super().invoke(*args, **kwargs)
+        return super().invoke(*args, **kwargs)
+
+
+runner = _CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _attach_capmanager(request):
+    """Give the CLI runner access to pytest's capture manager for this test."""
+    runner.capmanager = request.config.pluginmanager.getplugin("capturemanager")
+    yield
+    runner.capmanager = None
 
 
 def pg_upsert_cli(command_string):

--- a/uv.lock
+++ b/uv.lock
@@ -1046,7 +1046,7 @@ requires-dist = [
     { name = "openpyxl", marker = "extra == 'xlsx'", specifier = ">=3.1" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1,<4" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "<9.1" },
+    { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "python-dotenv", marker = "extra == 'dev'" },
     { name = "pyyaml", specifier = ">=6.0.1" },
@@ -1387,7 +1387,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1398,9 +1398,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Removes the temporary `pytest<9.1` dev pin by fixing the two root causes behind the CLI test failures under pytest 9.1.

### 1. typer `CliRunner` × pytest 9.1 capture conflict
typer's `CliRunner` does its own stdout/stderr capture; under pytest 9.1's changed capture handling the runner's buffer is closed before it can be read (`ValueError: I/O operation on closed file`). Fixed with a `CliRunner` subclass that disables pytest capture only for the duration of each `invoke` — the same mechanism as `capsys.disabled()`. (Confirmed: the test passes with `-s` but fails with capture on.)

### 2. `CustomLogFormatter` mutated the shared `LogRecord`
The debug formatter rewrote `record.lineno` (to a padded string), `record.name`, and `record.levelname` **in place**. Python's logging passes one record object to every handler, so this corrupted formatting for other handlers on the chain — including pytest's capture handler, whose `%(lineno)d` then raised `TypeError: %d format: not str` when a later test (`test_export`) logged. This was the cascade that turned ~23 CLI failures into 55. The formatter now works on a copy. This is also a real product bug (it could leak a non-int `lineno` and ANSI codes into a configured logfile handler).

## Verification
- Full suite passes on **pytest 9.1.1** (365 passed, 91.86% coverage), both unit-only (no DB) and integration (with DB).
- `ruff` clean.
- Dev lock moved to pytest 9.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)