### PR TITLE
Config from PgUpsert(): from_config(), layered sources, and per-table excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ ______________________________________________________________________
 ### Added
 
 - **`PgUpsert.from_config()`** — construct a `PgUpsert` directly from a YAML configuration file (or a dict), the same file accepted by the CLI's `--config-file` (resolves [#14](https://github.com/geocoug/pg-upsert/issues/14)). Both CLI-style keys (`exclude_columns`, `null_columns`, `commit`) and native constructor names (`exclude_cols`, `do_commit`) are accepted; unknown keys are ignored. Connection parts (`host`, `port`, `database`, `user`) are assembled into a URI when one is not supplied, and `**overrides` (including non-YAML values like `conn` or `callback`) take precedence over the file. Example: `PgUpsert.from_config("pg-upsert.yaml", do_commit=True)`.
+- **Per-table column excludes** (resolves [#30](https://github.com/geocoug/pg-upsert/issues/30)) — new `exclude_cols_by_table` and `exclude_null_check_cols_by_table` constructor parameters (config-file keys `exclude_columns_by_table` and `null_columns_by_table`) map a table name to its own column list. These are merged on top of the global `exclude_cols` / `exclude_null_check_cols` lists for that table, so a column can be excluded everywhere, only on specific tables, or both. Every key must be one of the configured tables.
 
 ### Changed
 
 - The CLI now builds its `PgUpsert` instance through the shared `pg_upsert.config` loader, so command-line and `from_config()` usage share a single source of truth for config-key handling and cannot drift.
+- **Config parameter handling enhanced** in `config_to_kwargs()` to properly normalize dictionary values for per-table column exclusion parameters.
+- **CLI imports `is_recognized_key`** from the config module to validate configuration keys from YAML files, ensuring only recognized keys are accepted during config file parsing.
+- **Example configuration documentation improved** — `pg-upsert.example.yaml` now includes inline comments explaining the purpose of `exclude_columns` and `null_columns`, plus commented-out examples showing how to configure per-table column exclusions via `exclude_columns_by_table` and `null_columns_by_table`.
 
 ______________________________________________________________________
 
@@ -36,8 +40,6 @@ ______________________________________________________________________
 
 - **Upper bounds removed from `typer` and `pyyaml` dependencies.** Both are now pinned only by a lower bound (`typer>=0.15`, `pyyaml>=6.0.1`) so downstream projects can pick up newer releases without resolver conflicts. Resolved versions in the lock file move to `typer 0.26.x` and `pyyaml 6.0.3`.
 - **CLI exit code when invoked with no arguments is now `2` (was `0`).** Click 8.2+ standardized `no_args_is_help` to exit with the usage-error code; the help text is still printed. Scripts that previously checked `pg-upsert; echo $?` for `0` on a bare invocation must be updated.
-
-______________________________________________________________________
 
 ## [1.22.0] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ ______________________________________________________________________
 
 ## [Unreleased]
 
+### Added
+
+- **`PgUpsert.from_config()`** — construct a `PgUpsert` directly from a YAML configuration file (or a dict), the same file accepted by the CLI's `--config-file` (resolves [#14](https://github.com/geocoug/pg-upsert/issues/14)). Both CLI-style keys (`exclude_columns`, `null_columns`, `commit`) and native constructor names (`exclude_cols`, `do_commit`) are accepted; unknown keys are ignored. Connection parts (`host`, `port`, `database`, `user`) are assembled into a URI when one is not supplied, and `**overrides` (including non-YAML values like `conn` or `callback`) take precedence over the file. Example: `PgUpsert.from_config("pg-upsert.yaml", do_commit=True)`.
+
+### Changed
+
+- The CLI now builds its `PgUpsert` instance through the shared `pg_upsert.config` loader, so command-line and `from_config()` usage share a single source of truth for config-key handling and cannot drift.
+
 ______________________________________________________________________
 
 ## [1.23.0] - 2026-06-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,12 @@ ______________________________________________________________________
 
 ### Added
 
-- **`PgUpsert.from_config()`** — construct a `PgUpsert` directly from a YAML configuration file (or a dict), the same file accepted by the CLI's `--config-file` (resolves [#14](https://github.com/geocoug/pg-upsert/issues/14)). Both CLI-style keys (`exclude_columns`, `null_columns`, `commit`) and native constructor names (`exclude_cols`, `do_commit`) are accepted; unknown keys are ignored. Connection parts (`host`, `port`, `database`, `user`) are assembled into a URI when one is not supplied, and `**overrides` (including non-YAML values like `conn` or `callback`) take precedence over the file. Example: `PgUpsert.from_config("pg-upsert.yaml", do_commit=True)`.
+- **`PgUpsert.from_config()`** — construct a `PgUpsert` directly from a YAML configuration file (or a dict), the same file accepted by the CLI's `--config-file` (resolves [#14](https://github.com/geocoug/pg-upsert/issues/14)). Accepts a single path/dict *or* a `list`/`tuple` of sources, which are shallow-merged left-to-right so later sources override earlier ones key-by-key (e.g. `from_config(["base.yaml", "task.yaml"])`). Both CLI-style keys (`exclude_columns`, `null_columns`, `commit`) and native constructor names (`exclude_cols`, `do_commit`) are accepted; unknown keys are ignored. Connection parts (`host`, `port`, `database`, `user`) are assembled into a URI when one is not supplied, and `**overrides` (including non-YAML values like `conn` or `callback`) take precedence over all files. Examples: `PgUpsert.from_config("pg-upsert.yaml")`, `PgUpsert.from_config("pg-upsert.yaml", do_commit=True)`, `PgUpsert.from_config(["base.yaml", "task.yaml"])`.
 - **Per-table column excludes** (resolves [#30](https://github.com/geocoug/pg-upsert/issues/30)) — new `exclude_cols_by_table` and `exclude_null_check_cols_by_table` constructor parameters (config-file keys `exclude_columns_by_table` and `null_columns_by_table`) map a table name to its own column list. These are merged on top of the global `exclude_cols` / `exclude_null_check_cols` lists for that table, so a column can be excluded everywhere, only on specific tables, or both. Every key must be one of the configured tables.
 
 ### Changed
 
 - The CLI now builds its `PgUpsert` instance through the shared `pg_upsert.config` loader, so command-line and `from_config()` usage share a single source of truth for config-key handling and cannot drift.
-- **Config parameter handling enhanced** in `config_to_kwargs()` to properly normalize dictionary values for per-table column exclusion parameters.
-- **CLI imports `is_recognized_key`** from the config module to validate configuration keys from YAML files, ensuring only recognized keys are accepted during config file parsing.
-- **Example configuration documentation improved** — `pg-upsert.example.yaml` now includes inline comments explaining the purpose of `exclude_columns` and `null_columns`, plus commented-out examples showing how to configure per-table column exclusions via `exclude_columns_by_table` and `null_columns_by_table`.
 
 ______________________________________________________________________
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -311,6 +311,40 @@ ups.cleanup()  # drops all ups_* temp objects; connection stays open
 # conn is still usable for other work
 ```
 
+### 8 - Configure from a YAML file
+
+The same configuration file used by the CLI's `--config-file` flag can drive `PgUpsert` directly with `PgUpsert.from_config()`, so a single file works in both contexts:
+
+```yaml
+# pg-upsert.yaml
+host: localhost
+port: 5432
+user: docker
+database: dev
+staging_schema: staging
+base_schema: public
+tables:
+  - books
+  - authors
+exclude_columns:   # CLI-style keys are accepted (also: exclude_cols)
+  - rev_user
+  - rev_time
+commit: false      # maps to do_commit
+```
+
+```python
+from pg_upsert import PgUpsert
+
+# Build straight from the file...
+result = PgUpsert.from_config("pg-upsert.yaml").run()
+
+# ...or override individual values (overrides win over the file).
+# Overrides may include things YAML can't hold, e.g. an existing connection.
+result = PgUpsert.from_config("pg-upsert.yaml", do_commit=True).run()
+```
+
+Both CLI-style keys (`exclude_columns`, `null_columns`, `commit`) and the constructor's native names (`exclude_cols`, `do_commit`) are accepted, and unknown keys are ignored. When `host`, `port`, `database`, and `user` are present they are assembled into a connection URI; the password is prompted for (or read from `PGPASSWORD`) at connect time. A dictionary may be passed in place of a file path.
+
 ## CLI examples
 
 ```sh

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -345,6 +345,41 @@ result = PgUpsert.from_config("pg-upsert.yaml", do_commit=True).run()
 
 Both CLI-style keys (`exclude_columns`, `null_columns`, `commit`) and the constructor's native names (`exclude_cols`, `do_commit`) are accepted, and unknown keys are ignored. When `host`, `port`, `database`, and `user` are present they are assembled into a connection URI; the password is prompted for (or read from `PGPASSWORD`) at connect time. A dictionary may be passed in place of a file path.
 
+### 9 - Per-table column excludes
+
+`exclude_columns` / `null_columns` apply to every table. To exclude columns from specific tables, add `exclude_columns_by_table` / `null_columns_by_table` — these map a table name to its own column list and are **merged on top of** the global lists for that table (the global lists still apply everywhere):
+
+```yaml
+# pg-upsert.yaml
+exclude_columns:            # excluded from the upsert on every table
+  - rev_user
+  - rev_time
+exclude_columns_by_table:   # ...plus these, only on the named table
+  books:
+    - isbn_legacy
+null_columns_by_table:      # skip null checks for books.reprint_date only
+  books:
+    - reprint_date
+```
+
+With the config above, `books` excludes `rev_user`, `rev_time`, and `isbn_legacy` from the upsert; every other table excludes just `rev_user` and `rev_time`. The same mappings are available as constructor arguments:
+
+```python
+from pg_upsert import PgUpsert
+
+result = PgUpsert(
+    uri="postgresql://user@localhost:5432/dev",
+    tables=("books", "authors"),
+    staging_schema="staging",
+    base_schema="public",
+    exclude_cols=("rev_user", "rev_time"),
+    exclude_cols_by_table={"books": ["isbn_legacy"]},
+    exclude_null_check_cols_by_table={"books": ["reprint_date"]},
+).run()
+```
+
+Every key in a per-table mapping must be one of the configured `tables`, otherwise a `ValueError` is raised.
+
 ## CLI examples
 
 ```sh

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -311,7 +311,7 @@ ups.cleanup()  # drops all ups_* temp objects; connection stays open
 # conn is still usable for other work
 ```
 
-### 8 - Configure from a YAML file
+### 8 - Configure from a YAML file or files
 
 The same configuration file used by the CLI's `--config-file` flag can drive `PgUpsert` directly with `PgUpsert.from_config()`, so a single file works in both contexts:
 
@@ -341,9 +341,25 @@ result = PgUpsert.from_config("pg-upsert.yaml").run()
 # ...or override individual values (overrides win over the file).
 # Overrides may include things YAML can't hold, e.g. an existing connection.
 result = PgUpsert.from_config("pg-upsert.yaml", do_commit=True).run()
+
+# Layer multiple files: later sources override earlier ones key-by-key.
+# This is useful for a shared base config plus task-specific overrides.
+result = PgUpsert.from_config([
+    "base-config.yaml",      # shared defaults
+    "task-specific.yaml"      # task-specific overrides
+]).run()
 ```
 
 Both CLI-style keys (`exclude_columns`, `null_columns`, `commit`) and the constructor's native names (`exclude_cols`, `do_commit`) are accepted, and unknown keys are ignored. When `host`, `port`, `database`, and `user` are present they are assembled into a connection URI; the password is prompted for (or read from `PGPASSWORD`) at connect time. A dictionary may be passed in place of a file path.
+
+**Layering multiple files.** Pass a list (or tuple) of sources to keep a large shared config in one place and small task-specific overrides in another. Sources are shallow-merged left-to-right — later files override earlier ones key-by-key, and explicit overrides beat them all:
+
+```python
+# base.yaml has the connection + schemas; task.yaml has just the tables for this job.
+result = PgUpsert.from_config(["base.yaml", "task.yaml"]).run()
+```
+
+Merging is shallow: a key in a later file *replaces* the earlier value rather than being deep-merged. For example, a `tables` list (or an `exclude_columns_by_table` mapping) in `task.yaml` wholly replaces the one in `base.yaml` — it is not appended to or combined. Connection parts (`host`/`port`/`database`/`user`) merge across files before the URI is built, so a later file can override just the `user`. Multiple configuration sources can be passed as a `list` or `tuple` and are shallow-merged left-to-right, so later sources override earlier ones key-by-key.
 
 ### 9 - Per-table column excludes
 

--- a/docs/qa_checks.md
+++ b/docs/qa_checks.md
@@ -138,6 +138,20 @@ PgUpsert(
 
 CLI: `pg-upsert ... -n book_alias`
 
+### Per-table excludes
+
+`exclude_cols` and `exclude_null_check_cols` apply to every table. To target specific tables, pass `exclude_cols_by_table` / `exclude_null_check_cols_by_table` — mappings of table name to column list that are **merged on top of** the global lists for that table:
+
+```python
+PgUpsert(
+    ...,
+    exclude_cols=("rev_user", "rev_time"),       # every table
+    exclude_cols_by_table={"books": ["isbn_legacy"]},  # books also excludes isbn_legacy
+)
+```
+
+Each key must be one of the configured `tables`. These mappings are configuration-file and library only (there is no dedicated CLI flag); in a YAML config they are spelled `exclude_columns_by_table` and `null_columns_by_table`. See [Per-table column excludes](examples.md#9-per-table-column-excludes) for a full example.
+
 ### Enforcing strict column presence
 
 By default, missing columns that are not required (i.e., not primary key and not `NOT NULL` without a default) produce warnings rather than errors. Warnings are displayed but do not block the upsert pipeline. Set `strict_columns=True` to treat every missing staging column as an error:

--- a/pg-upsert.example.yaml
+++ b/pg-upsert.example.yaml
@@ -16,11 +16,18 @@ tables:
   - "books"
   - "book_authors"
   - "genres"
-exclude_columns:
+exclude_columns:  # Excluded from upsert on every table
   - "rev_time"
   - "rev_user"
-null_columns:
+null_columns:  # Skipped during null checks on every table
   - "book_alias"
+# Per-table excludes are merged on top of the global lists above.
+# exclude_columns_by_table:
+#   books:
+#     - "isbn_legacy"
+# null_columns_by_table:
+#   books:
+#     - "reprint_date"
 output: "text"  # Options: "text", "json"
 check_schema: false
 compact: false

--- a/src/pg_upsert/cli.py
+++ b/src/pg_upsert/cli.py
@@ -408,29 +408,9 @@ def cli(
                 "Pass a directory path (it will be created if missing).",
             )
     try:
-        from urllib.parse import quote
+        from .config import config_to_kwargs
 
-        ups = PgUpsert(
-            uri=(
-                f"postgresql://{quote(args.user, safe='')}"
-                f"@{quote(args.host, safe='')}:{args.port}"
-                f"/{quote(args.database, safe='')}"
-            ),
-            encoding=args.encoding,
-            tables=args.tables,
-            staging_schema=args.staging_schema,
-            base_schema=args.base_schema,
-            do_commit=args.commit,
-            upsert_method=args.upsert_method,
-            interactive=args.interactive,
-            exclude_cols=args.exclude_columns,
-            exclude_null_check_cols=args.null_columns,
-            ui_mode=args.ui_mode,
-            compact=args.compact,
-            capture_detail_rows=bool(args.export_failures),
-            max_export_rows=args.export_max_rows,
-            strict_columns=args.strict_columns,
-        )
+        ups = PgUpsert(**config_to_kwargs(vars(args)))
         if args.check_schema:
             from .ui import display
 

--- a/src/pg_upsert/cli.py
+++ b/src/pg_upsert/cli.py
@@ -14,6 +14,7 @@ import typer
 import yaml
 from rich import print as rprint
 
+from .config import is_recognized_key
 from .upsert import PgUpsert, UserCancelledError
 from .utils import CustomLogFormatter
 
@@ -320,6 +321,11 @@ def cli(
                             sys.exit(1)
                     else:
                         setattr(args, key, value)
+            elif is_recognized_key(key):
+                # Recognised config key without a matching CLI flag (e.g. the
+                # per-table exclude mappings). Pass it straight through to the
+                # constructor via config_to_kwargs(vars(args)).
+                setattr(args, key, config[key])
             else:
                 rprint(
                     f"Invalid configuration key will be ignored in {args.config_file}: {key}",

--- a/src/pg_upsert/config.py
+++ b/src/pg_upsert/config.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+"""Configuration loading shared by the CLI and :meth:`PgUpsert.from_config`.
+
+A single ``pg-upsert`` YAML configuration file can be used both on the command
+line (``--config-file``) and when constructing :class:`~pg_upsert.PgUpsert`
+directly (:meth:`PgUpsert.from_config`).  This module is the single source of
+truth for translating the file's (CLI-style) keys into the keyword arguments
+the :class:`~pg_upsert.PgUpsert` constructor expects, so the two entry points
+can never drift apart.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import yaml
+
+# Keyword arguments accepted by ``PgUpsert.__init__``. Anything outside this set
+# (plus the connection/alias keys handled below) is ignored so that a shared
+# config file may carry CLI-only keys such as ``host`` or ``output``.
+_VALID_PARAMS = frozenset(
+    {
+        "uri",
+        "conn",
+        "encoding",
+        "tables",
+        "staging_schema",
+        "base_schema",
+        "do_commit",
+        "interactive",
+        "upsert_method",
+        "exclude_cols",
+        "exclude_null_check_cols",
+        "control_table",
+        "ui_mode",
+        "compact",
+        "callback",
+        "capture_detail_rows",
+        "max_export_rows",
+        "strict_columns",
+    },
+)
+
+# CLI-style config keys mapped to their ``PgUpsert`` constructor counterparts.
+_ALIASES = {
+    "exclude_columns": "exclude_cols",
+    "null_columns": "exclude_null_check_cols",
+    "commit": "do_commit",
+    "export_max_rows": "max_export_rows",
+    "ui": "ui_mode",
+}
+
+# Config keys whose values are comma-separated strings on the CLI but lists in
+# the constructor.
+_LIST_KEYS = frozenset({"tables", "exclude_cols", "exclude_null_check_cols"})
+
+# Connection keys consumed to build a URI when one is not supplied directly.
+_CONN_KEYS = frozenset({"host", "port", "database", "user"})
+
+
+def load_config(path: str | Path) -> dict[str, Any]:
+    """Read and parse a YAML configuration file.
+
+    Args:
+        path: Path to the configuration YAML file.
+
+    Returns:
+        The parsed configuration as a dictionary (empty if the file is blank).
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the file is not valid YAML or does not contain a mapping.
+    """
+    config_path = Path(path)
+    if not config_path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+    try:
+        with open(config_path) as file:
+            config = yaml.safe_load(file)
+    except (yaml.YAMLError, OSError) as e:
+        raise ValueError(f"Error reading configuration file {config_path}: {e}") from e
+    if config is None:
+        return {}
+    if not isinstance(config, dict):
+        raise ValueError(
+            f"Configuration file {config_path} must contain a mapping of keys to values, got {type(config).__name__}.",
+        )
+    return config
+
+
+def build_uri(*, host: str, database: str, user: str, port: int | str = 5432) -> str:
+    """Build a PostgreSQL connection URI (without a password) from parts.
+
+    The password is intentionally omitted; :class:`~pg_upsert.PostgresDB`
+    prompts for it (or reads ``PGPASSWORD``) when the connection is opened.
+    """
+    return (
+        f"postgresql://{quote(str(user), safe='')}@{quote(str(host), safe='')}:{port}/{quote(str(database), safe='')}"
+    )
+
+
+def _as_list(value: Any) -> Any:
+    """Normalise a comma-separated string into a list of trimmed values."""
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return value
+
+
+def config_to_kwargs(config: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    """Translate a config mapping into ``PgUpsert`` constructor keyword arguments.
+
+    Accepts both CLI-style keys (e.g. ``exclude_columns``, ``commit``) and the
+    constructor's native names (e.g. ``exclude_cols``, ``do_commit``).  Unknown
+    keys are ignored so a single file can be shared between the CLI and the
+    library.  Explicit ``overrides`` take precedence over the file's values.
+
+    Args:
+        config: Parsed configuration mapping.
+        **overrides: Keyword arguments that win over the config file. May
+            include non-serialisable values such as ``conn`` or ``callback``.
+
+    Returns:
+        A dictionary of keyword arguments suitable for ``PgUpsert(**kwargs)``.
+    """
+    merged: dict[str, Any] = {**config, **overrides}
+    kwargs: dict[str, Any] = {}
+
+    for key, value in merged.items():
+        param = _ALIASES.get(key, key)
+        if param in _VALID_PARAMS:
+            kwargs[param] = _as_list(value) if param in _LIST_KEYS else value
+
+    # ``--export-failures`` implies row capture so failures can be exported.
+    if merged.get("export_failures") and "capture_detail_rows" not in kwargs:
+        kwargs["capture_detail_rows"] = True
+
+    # Build a connection URI from parts only when one is not supplied directly.
+    if not kwargs.get("uri") and not kwargs.get("conn"):
+        conn_parts = {k: merged[k] for k in _CONN_KEYS if merged.get(k)}
+        if {"host", "database", "user"} <= conn_parts.keys():
+            kwargs["uri"] = build_uri(
+                host=conn_parts["host"],
+                database=conn_parts["database"],
+                user=conn_parts["user"],
+                port=conn_parts.get("port", 5432),
+            )
+
+    return kwargs

--- a/src/pg_upsert/config.py
+++ b/src/pg_upsert/config.py
@@ -33,6 +33,8 @@ _VALID_PARAMS = frozenset(
         "upsert_method",
         "exclude_cols",
         "exclude_null_check_cols",
+        "exclude_cols_by_table",
+        "exclude_null_check_cols_by_table",
         "control_table",
         "ui_mode",
         "compact",
@@ -47,6 +49,8 @@ _VALID_PARAMS = frozenset(
 _ALIASES = {
     "exclude_columns": "exclude_cols",
     "null_columns": "exclude_null_check_cols",
+    "exclude_columns_by_table": "exclude_cols_by_table",
+    "null_columns_by_table": "exclude_null_check_cols_by_table",
     "commit": "do_commit",
     "export_max_rows": "max_export_rows",
     "ui": "ui_mode",
@@ -55,6 +59,10 @@ _ALIASES = {
 # Config keys whose values are comma-separated strings on the CLI but lists in
 # the constructor.
 _LIST_KEYS = frozenset({"tables", "exclude_cols", "exclude_null_check_cols"})
+
+# Config keys whose values are mappings of table name to a (comma-separated or
+# list) set of columns. Each mapping value is normalised to a list.
+_DICT_LIST_KEYS = frozenset({"exclude_cols_by_table", "exclude_null_check_cols_by_table"})
 
 # Connection keys consumed to build a URI when one is not supplied directly.
 _CONN_KEYS = frozenset({"host", "port", "database", "user"})
@@ -129,8 +137,14 @@ def config_to_kwargs(config: dict[str, Any], **overrides: Any) -> dict[str, Any]
 
     for key, value in merged.items():
         param = _ALIASES.get(key, key)
-        if param in _VALID_PARAMS:
-            kwargs[param] = _as_list(value) if param in _LIST_KEYS else value
+        if param not in _VALID_PARAMS:
+            continue
+        if param in _LIST_KEYS:
+            kwargs[param] = _as_list(value)
+        elif param in _DICT_LIST_KEYS and isinstance(value, dict):
+            kwargs[param] = {table: _as_list(cols) for table, cols in value.items()}
+        else:
+            kwargs[param] = value
 
     # ``--export-failures`` implies row capture so failures can be exported.
     if merged.get("export_failures") and "capture_detail_rows" not in kwargs:
@@ -148,3 +162,13 @@ def config_to_kwargs(config: dict[str, Any], **overrides: Any) -> dict[str, Any]
             )
 
     return kwargs
+
+
+def is_recognized_key(key: str) -> bool:
+    """Return ``True`` if *key* is a known config key (native, alias, or connection).
+
+    Used by the CLI to decide whether a config-file key that has no matching
+    command-line flag (e.g. ``exclude_columns_by_table``) should still be passed
+    through to the constructor rather than warned about as unknown.
+    """
+    return key in _VALID_PARAMS or key in _ALIASES or key in _CONN_KEYS or key == "export_failures"

--- a/src/pg_upsert/config.py
+++ b/src/pg_upsert/config.py
@@ -98,6 +98,55 @@ def load_config(path: str | Path) -> dict[str, Any]:
     return config
 
 
+def _canonicalize(config: dict[str, Any]) -> dict[str, Any]:
+    """Rename CLI-style alias keys to their canonical names (shallow).
+
+    Ensures that, when several config sources are merged, the same setting
+    spelled two ways (e.g. ``commit`` and ``do_commit``) collapses onto one
+    key so later sources override earlier ones cleanly.
+    """
+    return {_ALIASES.get(key, key): value for key, value in config.items()}
+
+
+def merge_configs(sources: list[dict[str, Any]] | tuple[dict[str, Any], ...]) -> dict[str, Any]:
+    """Shallow-merge config mappings left-to-right; later sources win.
+
+    Each top-level key is wholly replaced by the value from the last source
+    that sets it (no deep/recursive merging of nested lists or dicts). Alias
+    keys are canonicalised first so different spellings of the same setting
+    override one another rather than coexisting.
+
+    Args:
+        sources: Ordered config mappings, lowest precedence first.
+
+    Returns:
+        A single merged mapping.
+    """
+    merged: dict[str, Any] = {}
+    for source in sources:
+        merged.update(_canonicalize(source))
+    return merged
+
+
+def load_sources(config: str | Path | dict | list | tuple) -> dict[str, Any]:
+    """Resolve one or more config sources into a single merged mapping.
+
+    Accepts a single source (a path or an already-parsed mapping) or an
+    ordered ``list``/``tuple`` of them. Paths are read from disk; mappings are
+    used as-is. Multiple sources are shallow-merged with later entries
+    overriding earlier ones (see :func:`merge_configs`).
+
+    Args:
+        config: A path, a mapping, or a list/tuple of paths and/or mappings.
+
+    Returns:
+        The merged configuration mapping.
+    """
+    sources = list(config) if isinstance(config, (list, tuple)) else [config]
+    dicts = [src if isinstance(src, dict) else load_config(src) for src in sources]
+    return merge_configs(dicts)
+
+
 def build_uri(*, host: str, database: str, user: str, port: int | str = 5432) -> str:
     """Build a PostgreSQL connection URI (without a password) from parts.
 

--- a/src/pg_upsert/control.py
+++ b/src/pg_upsert/control.py
@@ -13,6 +13,24 @@ logger = logging.getLogger(__name__)
 _file_logger = logging.getLogger("pg_upsert.display")
 
 
+def _merge_excludes(
+    global_cols: list[str] | tuple[str, ...] | None,
+    by_table: dict[str, list[str] | tuple[str, ...]] | None,
+    table: str,
+) -> list[str]:
+    """Merge global and per-table exclude lists for *table*, preserving order.
+
+    The global list applies to every table; per-table entries are appended on
+    top. Duplicates are removed while keeping first-seen order so the result is
+    stable regardless of overlap between the two lists.
+    """
+    merged: list[str] = []
+    for col in list(global_cols or ()) + list((by_table or {}).get(table, ())):
+        if col not in merged:
+            merged.append(col)
+    return merged
+
+
 class ControlTable:
     """Manages the temporary upsert control table in the database.
 
@@ -51,6 +69,8 @@ class ControlTable:
         exclude_cols: list[str] | tuple[str, ...] | None,
         exclude_null_check_cols: list[str] | tuple[str, ...] | None,
         interactive: bool,
+        exclude_cols_by_table: dict[str, list[str] | tuple[str, ...]] | None = None,
+        exclude_null_check_cols_by_table: dict[str, list[str] | tuple[str, ...]] | None = None,
     ) -> None:
         """Create and populate the control table.
 
@@ -58,11 +78,20 @@ class ControlTable:
         per table.  Exclude-column lists and the ``interactive`` flag are
         written into the table when provided.
 
+        The global ``exclude_cols`` / ``exclude_null_check_cols`` lists apply
+        to every table; the optional ``*_by_table`` mappings add table-specific
+        columns on top of (merged with) the global lists.
+
         Args:
             tables: Ordered list of table names to process.
-            exclude_cols: Column names to skip during upsert.
-            exclude_null_check_cols: Column names to skip during null checks.
+            exclude_cols: Column names to skip during upsert (all tables).
+            exclude_null_check_cols: Column names to skip during null checks
+                (all tables).
             interactive: Whether the run is interactive.
+            exclude_cols_by_table: Per-table upsert excludes, merged with the
+                global ``exclude_cols`` list.
+            exclude_null_check_cols_by_table: Per-table null-check excludes,
+                merged with the global ``exclude_null_check_cols`` list.
         """
         logger.debug("Initializing upsert control table")
         sql = SQL(
@@ -94,29 +123,29 @@ class ControlTable:
         )
         self.db.execute(sql)
 
-        if exclude_cols and len(exclude_cols) > 0:
-            self.db.execute(
-                SQL(
-                    """
-                    update {control_table}
-                    set exclude_cols = {exclude_cols};
-                """,
-                ).format(
-                    control_table=Identifier(self.table_name),
-                    exclude_cols=Literal(",".join(exclude_cols)),
-                ),
+        # Write merged (global + per-table) excludes into each table's row.
+        for table in tables:
+            merged_cols = _merge_excludes(exclude_cols, exclude_cols_by_table, table)
+            merged_null = _merge_excludes(
+                exclude_null_check_cols,
+                exclude_null_check_cols_by_table,
+                table,
             )
-
-        if exclude_null_check_cols and len(exclude_null_check_cols) > 0:
+            if not merged_cols and not merged_null:
+                continue
             self.db.execute(
                 SQL(
                     """
                     update {control_table}
-                    set exclude_null_checks = {exclude_null_check_cols};
+                    set exclude_cols = {exclude_cols},
+                        exclude_null_checks = {exclude_null_checks}
+                    where table_name = {table};
                 """,
                 ).format(
                     control_table=Identifier(self.table_name),
-                    exclude_null_check_cols=Literal(",".join(exclude_null_check_cols)),
+                    exclude_cols=Literal(",".join(merged_cols)) if merged_cols else Literal(None),
+                    exclude_null_checks=Literal(",".join(merged_null)) if merged_null else Literal(None),
+                    table=Literal(table),
                 ),
             )
 
@@ -284,7 +313,7 @@ class ControlTable:
         rows, _headers, rowcount = self.db.rowdict(
             SQL(
                 """
-            select table_name, exclude_cols, interactive
+            select table_name, exclude_cols, exclude_null_checks, interactive
             from {control_table}
             where table_name = {table};
             """,

--- a/src/pg_upsert/qa.py
+++ b/src/pg_upsert/qa.py
@@ -74,6 +74,19 @@ class QARunner:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _table_null_excludes(self, table: str) -> list[str]:
+        """Return the null-check excludes for *table*.
+
+        Reads the per-table value resolved into the control table (which
+        already merges the global list with any per-table additions). Falls
+        back to the global ``exclude_null_check_cols`` attribute when no
+        control row exists for the table.
+        """
+        spec = self.control.get_table_spec(table)
+        if spec and spec.get("exclude_null_checks"):
+            return [c.strip() for c in spec["exclude_null_checks"].split(",") if c.strip()]
+        return list(self.exclude_null_check_cols)
+
     def _get_pk_columns(self, table: str) -> list[str]:
         """Return the PK column names for *table* in the base schema.
 
@@ -135,9 +148,13 @@ class QARunner:
                 and is_nullable = 'NO'
                 and column_default is null""",
         ).format(base_schema=Literal(self.base_schema), table=Literal(table))
-        if self.exclude_null_check_cols:
+        # Prefer the per-table excludes resolved into the control table (which
+        # already merge the global list); fall back to the global attribute when
+        # the control row is absent (e.g. a QARunner used directly in tests).
+        exclude_null_cols = self._table_null_excludes(table)
+        if exclude_null_cols:
             col_query += SQL(" and column_name not in ({cols})").format(
-                cols=SQL(",").join(Literal(col) for col in self.exclude_null_check_cols),
+                cols=SQL(",").join(Literal(col) for col in exclude_null_cols),
             )
         col_rows, _ch, _cc = self.db.rowdict(col_query)
         nonnull_cols = [r["column_name"] for r in col_rows]

--- a/src/pg_upsert/upsert.py
+++ b/src/pg_upsert/upsert.py
@@ -57,6 +57,8 @@ class PgUpsert:
         upsert_method (str, optional): The method to use for upserting data. Must be one of "upsert", "update", or "insert". Defaults to "upsert".
         exclude_cols (list or tuple or None, optional): List of column names to exclude from the upsert process. These columns will not be updated or inserted to, however, they will still be checked during the QA process.
         exclude_null_check_cols (list or tuple or None, optional): List of column names to exclude from the not-null check during the QA process. You may wish to exclude certain columns from null checks, such as auto-generated timestamps or serial columns as they may not be populated until after records are inserted or updated. Defaults to ().
+        exclude_cols_by_table (dict or None, optional): Per-table upsert excludes, mapping a table name to a list of column names. These are merged with (added on top of) the global ``exclude_cols`` list for that table. Every key must be one of the configured ``tables``. Defaults to ``None``.
+        exclude_null_check_cols_by_table (dict or None, optional): Per-table null-check excludes, mapping a table name to a list of column names. These are merged with the global ``exclude_null_check_cols`` list for that table. Every key must be one of the configured ``tables``. Defaults to ``None``.
         control_table (str, optional): Name of the temporary control table that will be used to track changes during the upsert process. Defaults to "ups_control".
         ui_mode (str, optional): Interactive UI backend to use when ``interactive=True``. One of ``"auto"`` (pick tkinter if a display is available, else textual), ``"tkinter"`` (force desktop GUI), or ``"textual"`` (force terminal TUI). When ``interactive=False`` this is ignored and a non-interactive console backend is used internally. Defaults to ``"auto"``.
         compact (bool, optional): If ``True``, render the QA summary as a compact ``✓``/``✗`` grid (one row per table, one column per check type) instead of a per-check panel. Useful for runs with many tables. Defaults to ``False``.
@@ -131,6 +133,8 @@ class PgUpsert:
         upsert_method: str = "upsert",
         exclude_cols: list | tuple | None = (),
         exclude_null_check_cols: list | tuple | None = (),
+        exclude_cols_by_table: dict | None = None,
+        exclude_null_check_cols_by_table: dict | None = None,
         control_table: str = "ups_control",
         ui_mode: str = "auto",
         compact: bool = False,
@@ -156,6 +160,16 @@ class PgUpsert:
             raise ValueError(
                 f"Staging and base schemas must be different. Got {staging_schema} for both.",
             )
+        exclude_cols_by_table = self._validate_by_table(
+            exclude_cols_by_table,
+            tables,
+            "exclude_cols_by_table",
+        )
+        exclude_null_check_cols_by_table = self._validate_by_table(
+            exclude_null_check_cols_by_table,
+            tables,
+            "exclude_null_check_cols_by_table",
+        )
         self.db = PostgresDB(
             uri=uri,
             conn=conn,
@@ -170,6 +184,8 @@ class PgUpsert:
         self.upsert_method = upsert_method
         self.exclude_cols = exclude_cols
         self.exclude_null_check_cols = exclude_null_check_cols
+        self.exclude_cols_by_table = exclude_cols_by_table
+        self.exclude_null_check_cols_by_table = exclude_null_check_cols_by_table
         self.control_table = control_table
         self.compact = compact
         self.qa_passed = False
@@ -210,7 +226,45 @@ class PgUpsert:
             exclude_cols=list(exclude_cols) if exclude_cols else None,
             exclude_null_check_cols=list(exclude_null_check_cols) if exclude_null_check_cols else None,
             interactive=interactive,
+            exclude_cols_by_table=exclude_cols_by_table,
+            exclude_null_check_cols_by_table=exclude_null_check_cols_by_table,
         )
+
+    @staticmethod
+    def _validate_by_table(
+        by_table: dict | None,
+        tables: list | tuple,
+        param_name: str,
+    ) -> dict | None:
+        """Validate a per-table exclude mapping and normalise its values to lists.
+
+        Ensures the argument is a ``dict`` of table names (each present in
+        *tables*) to iterables of column-name strings. Returns ``None`` when the
+        mapping is empty so downstream code can treat it uniformly.
+        """
+        if not by_table:
+            return None
+        if not isinstance(by_table, dict):
+            raise ValueError(
+                f"{param_name} must be a mapping of table name to column list, got {type(by_table).__name__}",
+            )
+        known = set(tables)
+        normalised: dict[str, list[str]] = {}
+        for table, cols in by_table.items():
+            if table not in known:
+                raise ValueError(
+                    f"{param_name} references table {table!r} which is not in the configured tables {tuple(tables)}",
+                )
+            if isinstance(cols, str):
+                cols = [c.strip() for c in cols.split(",") if c.strip()]
+            elif isinstance(cols, (list, tuple)):
+                cols = [str(c) for c in cols]
+            else:
+                raise ValueError(
+                    f"{param_name}[{table!r}] must be a list of column names, got {type(cols).__name__}",
+                )
+            normalised[table] = cols
+        return normalised or None
 
     @classmethod
     def from_config(
@@ -423,6 +477,8 @@ class PgUpsert:
             exclude_cols=list(self.exclude_cols) if self.exclude_cols else None,
             exclude_null_check_cols=(list(self.exclude_null_check_cols) if self.exclude_null_check_cols else None),
             interactive=self.interactive,
+            exclude_cols_by_table=self.exclude_cols_by_table,
+            exclude_null_check_cols_by_table=self.exclude_null_check_cols_by_table,
         )
 
     def show_control(self: PgUpsert) -> None:

--- a/src/pg_upsert/upsert.py
+++ b/src/pg_upsert/upsert.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from pathlib import Path
 
 import psycopg
 from psycopg.sql import SQL, Identifier, Literal
@@ -210,6 +211,48 @@ class PgUpsert:
             exclude_null_check_cols=list(exclude_null_check_cols) if exclude_null_check_cols else None,
             interactive=interactive,
         )
+
+    @classmethod
+    def from_config(
+        cls,
+        config: str | Path | dict,
+        **overrides,
+    ) -> PgUpsert:
+        """Construct a :class:`PgUpsert` from a configuration file or mapping.
+
+        Accepts the same YAML configuration file used by the command line
+        (``--config-file``), so a single file can drive both the CLI and
+        library usage. CLI-style keys (e.g. ``exclude_columns``, ``commit``,
+        ``null_columns``) and the constructor's native names (e.g.
+        ``exclude_cols``, ``do_commit``) are both accepted; unrecognised keys
+        are ignored. Connection parts (``host``, ``port``, ``database``,
+        ``user``) are assembled into a URI when one is not supplied directly —
+        the password is prompted for (or read from ``PGPASSWORD``) at connect
+        time.
+
+        Args:
+            config: Path to a YAML configuration file, or an already-parsed
+                mapping of configuration values.
+            **overrides: Keyword arguments that take precedence over the config
+                file's values. May include values that cannot live in YAML,
+                such as an existing ``conn`` or a ``callback``.
+
+        Returns:
+            A configured :class:`PgUpsert` instance.
+
+        Raises:
+            FileNotFoundError: If ``config`` is a path that does not exist.
+            ValueError: If the configuration is not a valid mapping or required
+                arguments are missing.
+
+        Example:
+            >>> ups = PgUpsert.from_config("pg-upsert.yaml")
+            >>> ups = PgUpsert.from_config("pg-upsert.yaml", do_commit=True)
+        """
+        from .config import config_to_kwargs, load_config
+
+        data = config if isinstance(config, dict) else load_config(config)
+        return cls(**config_to_kwargs(data, **overrides))
 
     @property
     def qa_errors(self) -> list[QAError]:

--- a/src/pg_upsert/upsert.py
+++ b/src/pg_upsert/upsert.py
@@ -269,10 +269,10 @@ class PgUpsert:
     @classmethod
     def from_config(
         cls,
-        config: str | Path | dict,
+        config: str | Path | dict | list | tuple,
         **overrides,
     ) -> PgUpsert:
-        """Construct a :class:`PgUpsert` from a configuration file or mapping.
+        """Construct a :class:`PgUpsert` from one or more configuration sources.
 
         Accepts the same YAML configuration file used by the command line
         (``--config-file``), so a single file can drive both the CLI and
@@ -284,29 +284,37 @@ class PgUpsert:
         the password is prompted for (or read from ``PGPASSWORD``) at connect
         time.
 
+        Passing a ``list``/``tuple`` of sources layers them: they are
+        shallow-merged left-to-right, so later sources override earlier ones
+        key-by-key (no deep merging — a later ``tables`` or
+        ``exclude_columns_by_table`` wholly replaces an earlier one). This lets
+        a small task-specific file override a larger shared base file. Explicit
+        ``overrides`` win over every file.
+
         Args:
-            config: Path to a YAML configuration file, or an already-parsed
-                mapping of configuration values.
-            **overrides: Keyword arguments that take precedence over the config
-                file's values. May include values that cannot live in YAML,
+            config: A path to a YAML file or an already-parsed mapping, or an
+                ordered ``list``/``tuple`` of such sources (lowest precedence
+                first).
+            **overrides: Keyword arguments that take precedence over every
+                config source. May include values that cannot live in YAML,
                 such as an existing ``conn`` or a ``callback``.
 
         Returns:
             A configured :class:`PgUpsert` instance.
 
         Raises:
-            FileNotFoundError: If ``config`` is a path that does not exist.
-            ValueError: If the configuration is not a valid mapping or required
+            FileNotFoundError: If a source path does not exist.
+            ValueError: If a source is not a valid mapping or required
                 arguments are missing.
 
         Example:
             >>> ups = PgUpsert.from_config("pg-upsert.yaml")
             >>> ups = PgUpsert.from_config("pg-upsert.yaml", do_commit=True)
+            >>> ups = PgUpsert.from_config(["base.yaml", "task.yaml"])
         """
-        from .config import config_to_kwargs, load_config
+        from .config import config_to_kwargs, load_sources
 
-        data = config if isinstance(config, dict) else load_config(config)
-        return cls(**config_to_kwargs(data, **overrides))
+        return cls(**config_to_kwargs(load_sources(config), **overrides))
 
     @property
     def qa_errors(self) -> list[QAError]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+"""Tests for pg_upsert.config and PgUpsert.from_config — no database required."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from pg_upsert import PgUpsert
+from pg_upsert.config import (
+    build_uri,
+    config_to_kwargs,
+    load_config,
+)
+
+EXAMPLE_YAML = Path(__file__).resolve().parents[1] / "pg-upsert.example.yaml"
+
+
+# ---------------------------------------------------------------------------
+# load_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_reads_mapping(self, tmp_path):
+        path = tmp_path / "c.yaml"
+        path.write_text("host: localhost\nport: 5432\n")
+        assert load_config(path) == {"host": "localhost", "port": 5432}
+
+    def test_accepts_str_path(self, tmp_path):
+        path = tmp_path / "c.yaml"
+        path.write_text("user: docker\n")
+        assert load_config(str(path)) == {"user": "docker"}
+
+    def test_empty_file_returns_empty_dict(self, tmp_path):
+        path = tmp_path / "empty.yaml"
+        path.write_text("")
+        assert load_config(path) == {}
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_config(tmp_path / "nope.yaml")
+
+    def test_non_mapping_raises(self, tmp_path):
+        path = tmp_path / "list.yaml"
+        path.write_text("- a\n- b\n")
+        with pytest.raises(ValueError, match="must contain a mapping"):
+            load_config(path)
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        path = tmp_path / "bad.yaml"
+        path.write_text("a: [unterminated\n")
+        with pytest.raises(ValueError, match="Error reading configuration file"):
+            load_config(path)
+
+    def test_example_yaml_parses(self):
+        config = load_config(EXAMPLE_YAML)
+        assert config["staging_schema"] == "staging"
+        assert config["base_schema"] == "public"
+
+
+# ---------------------------------------------------------------------------
+# build_uri
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUri:
+    def test_basic(self):
+        uri = build_uri(host="localhost", database="dev", user="docker")
+        assert uri == "postgresql://docker@localhost:5432/dev"
+
+    def test_custom_port(self):
+        uri = build_uri(host="db", database="dev", user="u", port=6543)
+        assert uri == "postgresql://u@db:6543/dev"
+
+    def test_quotes_special_characters(self):
+        uri = build_uri(host="localhost", database="my db", user="a@b")
+        assert "a%40b" in uri
+        assert "my%20db" in uri
+
+
+# ---------------------------------------------------------------------------
+# config_to_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestConfigToKwargs:
+    def test_maps_cli_aliases_to_constructor_names(self):
+        kwargs = config_to_kwargs(
+            {
+                "exclude_columns": ["rev_time"],
+                "null_columns": ["alias"],
+                "commit": True,
+                "export_max_rows": 50,
+            },
+        )
+        assert kwargs["exclude_cols"] == ["rev_time"]
+        assert kwargs["exclude_null_check_cols"] == ["alias"]
+        assert kwargs["do_commit"] is True
+        assert kwargs["max_export_rows"] == 50
+
+    def test_accepts_native_param_names(self):
+        kwargs = config_to_kwargs({"exclude_cols": ["x"], "do_commit": True})
+        assert kwargs["exclude_cols"] == ["x"]
+        assert kwargs["do_commit"] is True
+
+    def test_splits_comma_separated_strings(self):
+        kwargs = config_to_kwargs({"exclude_columns": "a, b ,c", "tables": "t1,t2"})
+        assert kwargs["exclude_cols"] == ["a", "b", "c"]
+        assert kwargs["tables"] == ["t1", "t2"]
+
+    def test_ignores_unknown_keys(self):
+        kwargs = config_to_kwargs({"output": "json", "debug": True, "logfile": "x.log"})
+        assert "output" not in kwargs
+        assert "debug" not in kwargs
+        assert "logfile" not in kwargs
+
+    def test_builds_uri_from_connection_parts(self):
+        kwargs = config_to_kwargs(
+            {"host": "localhost", "database": "dev", "user": "docker", "port": 5432},
+        )
+        assert kwargs["uri"] == "postgresql://docker@localhost:5432/dev"
+
+    def test_does_not_build_uri_when_parts_incomplete(self):
+        kwargs = config_to_kwargs({"host": "localhost", "user": "docker"})
+        assert "uri" not in kwargs
+
+    def test_explicit_uri_preserved(self):
+        kwargs = config_to_kwargs(
+            {"host": "localhost", "database": "dev", "user": "docker", "uri": "postgresql://x@y/z"},
+        )
+        assert kwargs["uri"] == "postgresql://x@y/z"
+
+    def test_conn_override_skips_uri_building(self):
+        sentinel = object()
+        kwargs = config_to_kwargs(
+            {"host": "localhost", "database": "dev", "user": "docker"},
+            conn=sentinel,
+        )
+        assert "uri" not in kwargs
+        assert kwargs["conn"] is sentinel
+
+    def test_export_failures_enables_capture(self):
+        kwargs = config_to_kwargs({"export_failures": "out_dir"})
+        assert kwargs["capture_detail_rows"] is True
+
+    def test_export_failures_null_does_not_capture(self):
+        kwargs = config_to_kwargs({"export_failures": None})
+        assert "capture_detail_rows" not in kwargs
+
+    def test_overrides_take_precedence(self):
+        kwargs = config_to_kwargs({"commit": False, "do_commit": False}, do_commit=True)
+        assert kwargs["do_commit"] is True
+
+    def test_example_yaml_produces_valid_kwargs(self):
+        kwargs = config_to_kwargs(load_config(EXAMPLE_YAML))
+        assert kwargs["staging_schema"] == "staging"
+        assert kwargs["base_schema"] == "public"
+        assert kwargs["exclude_cols"] == ["rev_time", "rev_user"]
+        assert kwargs["uri"] == "postgresql://docker@localhost:5432/dev"
+        assert kwargs["do_commit"] is False
+
+
+# ---------------------------------------------------------------------------
+# PgUpsert.from_config
+# ---------------------------------------------------------------------------
+
+
+class TestFromConfig:
+    def test_missing_file_raises_before_construction(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            PgUpsert.from_config(tmp_path / "missing.yaml")
+
+    def test_routes_config_to_constructor(self):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        with mock.patch.object(PgUpsert, "__init__", fake_init):
+            PgUpsert.from_config(
+                {
+                    "host": "localhost",
+                    "database": "dev",
+                    "user": "docker",
+                    "staging_schema": "staging",
+                    "base_schema": "public",
+                    "tables": ["books"],
+                    "commit": True,
+                },
+            )
+        assert captured["uri"] == "postgresql://docker@localhost:5432/dev"
+        assert captured["staging_schema"] == "staging"
+        assert captured["tables"] == ["books"]
+        assert captured["do_commit"] is True
+
+    def test_overrides_reach_constructor(self):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        with mock.patch.object(PgUpsert, "__init__", fake_init):
+            PgUpsert.from_config(str(EXAMPLE_YAML), do_commit=True)
+        assert captured["do_commit"] is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,8 @@ from pg_upsert.config import (
     config_to_kwargs,
     is_recognized_key,
     load_config,
+    load_sources,
+    merge_configs,
 )
 
 EXAMPLE_YAML = Path(__file__).resolve().parents[1] / "pg-upsert.example.yaml"
@@ -60,6 +62,76 @@ class TestLoadConfig:
         config = load_config(EXAMPLE_YAML)
         assert config["staging_schema"] == "staging"
         assert config["base_schema"] == "public"
+
+
+# ---------------------------------------------------------------------------
+# merge_configs / load_sources (layered config)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeConfigs:
+    def test_later_source_wins(self):
+        assert merge_configs([{"host": "a"}, {"host": "b"}]) == {"host": "b"}
+
+    def test_keys_union_across_sources(self):
+        assert merge_configs([{"host": "a"}, {"user": "u"}]) == {"host": "a", "user": "u"}
+
+    def test_alias_collapses_across_sources(self):
+        # `commit` (file 1) and `do_commit` (file 2) are the same setting.
+        assert merge_configs([{"commit": False}, {"do_commit": True}]) == {"do_commit": True}
+
+    def test_shallow_replace_not_deep_merge_for_lists(self):
+        assert merge_configs([{"tables": ["a", "b"]}, {"tables": ["c"]}]) == {"tables": ["c"]}
+
+    def test_shallow_replace_not_deep_merge_for_dicts(self):
+        merged = merge_configs(
+            [
+                {"exclude_columns_by_table": {"books": ["x"]}},
+                {"exclude_columns_by_table": {"authors": ["y"]}},
+            ],
+        )
+        # The whole mapping is replaced, not deep-merged.
+        assert merged == {"exclude_cols_by_table": {"authors": ["y"]}}
+
+    def test_empty_sources(self):
+        assert merge_configs([]) == {}
+
+
+class TestLoadSources:
+    def test_single_dict(self):
+        assert load_sources({"host": "a"}) == {"host": "a"}
+
+    def test_single_path(self, tmp_path):
+        path = tmp_path / "c.yaml"
+        path.write_text("host: localhost\n")
+        assert load_sources(path) == {"host": "localhost"}
+
+    def test_list_of_dicts_layered(self):
+        merged = load_sources([{"host": "a", "user": "u1"}, {"user": "u2"}])
+        assert merged == {"host": "a", "user": "u2"}
+
+    def test_tuple_is_accepted(self):
+        assert load_sources(({"host": "a"}, {"host": "b"})) == {"host": "b"}
+
+    def test_mix_of_paths_and_dicts(self, tmp_path):
+        base = tmp_path / "base.yaml"
+        base.write_text("host: localhost\nuser: base\n")
+        merged = load_sources([base, {"user": "override"}])
+        assert merged == {"host": "localhost", "user": "override"}
+
+    def test_connection_parts_merge_then_build_uri(self):
+        merged = load_sources(
+            [
+                {"host": "h", "database": "dev", "user": "u1"},
+                {"user": "u2"},
+            ],
+        )
+        kwargs = config_to_kwargs(merged)
+        assert kwargs["uri"] == "postgresql://u2@h:5432/dev"
+
+    def test_missing_file_in_list_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_sources([{"host": "a"}, tmp_path / "missing.yaml"])
 
 
 # ---------------------------------------------------------------------------
@@ -246,3 +318,36 @@ class TestFromConfig:
         with mock.patch.object(PgUpsert, "__init__", fake_init):
             PgUpsert.from_config(str(EXAMPLE_YAML), do_commit=True)
         assert captured["do_commit"] is True
+
+    def test_layered_sources_later_wins(self):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        base = {
+            "host": "localhost",
+            "database": "dev",
+            "user": "base_user",
+            "staging_schema": "staging",
+            "base_schema": "public",
+            "tables": ["books", "authors"],
+            "commit": False,
+        }
+        task = {"user": "task_user", "tables": ["books"], "commit": True}
+        with mock.patch.object(PgUpsert, "__init__", fake_init):
+            PgUpsert.from_config([base, task])
+        # task overrides base key-by-key; connection parts merge before URI build.
+        assert captured["uri"] == "postgresql://task_user@localhost:5432/dev"
+        assert captured["tables"] == ["books"]
+        assert captured["do_commit"] is True
+
+    def test_overrides_beat_all_layers(self):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        with mock.patch.object(PgUpsert, "__init__", fake_init):
+            PgUpsert.from_config([{"commit": False}, {"commit": True}], do_commit=False)
+        assert captured["do_commit"] is False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ from pg_upsert import PgUpsert
 from pg_upsert.config import (
     build_uri,
     config_to_kwargs,
+    is_recognized_key,
     load_config,
 )
 
@@ -154,6 +155,20 @@ class TestConfigToKwargs:
         kwargs = config_to_kwargs({"commit": False, "do_commit": False}, do_commit=True)
         assert kwargs["do_commit"] is True
 
+    def test_normalizes_by_table_alias_and_values(self):
+        kwargs = config_to_kwargs(
+            {"exclude_columns_by_table": {"books": "a, b", "authors": ["c"]}},
+        )
+        assert kwargs["exclude_cols_by_table"] == {"books": ["a", "b"], "authors": ["c"]}
+
+    def test_null_columns_by_table_alias(self):
+        kwargs = config_to_kwargs({"null_columns_by_table": {"books": ["x"]}})
+        assert kwargs["exclude_null_check_cols_by_table"] == {"books": ["x"]}
+
+    def test_accepts_native_by_table_name(self):
+        kwargs = config_to_kwargs({"exclude_cols_by_table": {"books": ["x"]}})
+        assert kwargs["exclude_cols_by_table"] == {"books": ["x"]}
+
     def test_example_yaml_produces_valid_kwargs(self):
         kwargs = config_to_kwargs(load_config(EXAMPLE_YAML))
         assert kwargs["staging_schema"] == "staging"
@@ -161,6 +176,32 @@ class TestConfigToKwargs:
         assert kwargs["exclude_cols"] == ["rev_time", "rev_user"]
         assert kwargs["uri"] == "postgresql://docker@localhost:5432/dev"
         assert kwargs["do_commit"] is False
+
+
+# ---------------------------------------------------------------------------
+# is_recognized_key
+# ---------------------------------------------------------------------------
+
+
+class TestIsRecognizedKey:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "exclude_cols",
+            "exclude_cols_by_table",
+            "exclude_columns",
+            "exclude_columns_by_table",
+            "null_columns_by_table",
+            "host",
+            "export_failures",
+        ],
+    )
+    def test_recognized(self, key):
+        assert is_recognized_key(key) is True
+
+    @pytest.mark.parametrize("key", ["bogus", "output", "debug", ""])
+    def test_unrecognized(self, key):
+        assert is_recognized_key(key) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_per_table_excludes.py
+++ b/tests/test_per_table_excludes.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+"""Tests for per-table column excludes (issue #30).
+
+Pure-logic tests (merge + validation) run without a database; the
+integration tests that verify values land merged in the control table are
+marked ``@pytest.mark.postgres``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pg_upsert.control import _merge_excludes
+from pg_upsert.upsert import PgUpsert
+
+TABLES = ("genres", "books", "authors", "book_authors", "publishers")
+
+
+# ---------------------------------------------------------------------------
+# _merge_excludes (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeExcludes:
+    def test_global_only(self):
+        assert _merge_excludes(["a", "b"], None, "books") == ["a", "b"]
+
+    def test_per_table_appended_to_global(self):
+        assert _merge_excludes(["a"], {"books": ["b"]}, "books") == ["a", "b"]
+
+    def test_other_table_unaffected(self):
+        assert _merge_excludes(["a"], {"books": ["b"]}, "authors") == ["a"]
+
+    def test_dedup_preserves_first_seen_order(self):
+        assert _merge_excludes(["a", "b"], {"books": ["b", "c"]}, "books") == ["a", "b", "c"]
+
+    def test_all_empty(self):
+        assert _merge_excludes(None, None, "books") == []
+
+    def test_accepts_tuples(self):
+        assert _merge_excludes(("a",), {"books": ("b",)}, "books") == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# PgUpsert._validate_by_table (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateByTable:
+    def test_none_returns_none(self):
+        assert PgUpsert._validate_by_table(None, TABLES, "exclude_cols_by_table") is None
+
+    def test_empty_returns_none(self):
+        assert PgUpsert._validate_by_table({}, TABLES, "exclude_cols_by_table") is None
+
+    def test_normalises_comma_string_value(self):
+        result = PgUpsert._validate_by_table({"books": "a, b"}, TABLES, "exclude_cols_by_table")
+        assert result == {"books": ["a", "b"]}
+
+    def test_normalises_list_value_to_str(self):
+        result = PgUpsert._validate_by_table({"books": ["a", 1]}, TABLES, "exclude_cols_by_table")
+        assert result == {"books": ["a", "1"]}
+
+    def test_rejects_non_dict(self):
+        with pytest.raises(ValueError, match="must be a mapping"):
+            PgUpsert._validate_by_table(["books"], TABLES, "exclude_cols_by_table")
+
+    def test_rejects_unknown_table(self):
+        with pytest.raises(ValueError, match="not in the configured tables"):
+            PgUpsert._validate_by_table({"nope": ["x"]}, TABLES, "exclude_cols_by_table")
+
+    def test_rejects_bad_value_type(self):
+        with pytest.raises(ValueError, match="must be a list of column names"):
+            PgUpsert._validate_by_table({"books": 5}, TABLES, "exclude_cols_by_table")
+
+
+# ---------------------------------------------------------------------------
+# Integration: per-table excludes land merged in the control table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.postgres
+class TestPerTableExcludesIntegration:
+    def _make(self, db, **kwargs):
+        return PgUpsert(
+            conn=db.conn,
+            tables=TABLES,
+            staging_schema="staging",
+            base_schema="public",
+            do_commit=False,
+            interactive=False,
+            **kwargs,
+        )
+
+    def test_exclude_cols_merged_per_table(self, db):
+        ups = self._make(
+            db,
+            exclude_cols=("rev_user",),
+            exclude_cols_by_table={"books": ["rev_time"]},
+        )
+        books = ups._control.get_table_spec("books")
+        authors = ups._control.get_table_spec("authors")
+        # books gets global + per-table; authors gets global only.
+        assert set(books["exclude_cols"].split(",")) == {"rev_user", "rev_time"}
+        assert authors["exclude_cols"] == "rev_user"
+
+    def test_per_table_only_other_tables_empty(self, db):
+        ups = self._make(db, exclude_cols_by_table={"books": ["rev_time"]})
+        assert ups._control.get_table_spec("books")["exclude_cols"] == "rev_time"
+        assert not ups._control.get_table_spec("genres")["exclude_cols"]
+
+    def test_null_check_excludes_merged_per_table(self, db):
+        ups = self._make(
+            db,
+            exclude_null_check_cols_by_table={"books": ["book_alias"]},
+        )
+        assert ups._control.get_table_spec("books")["exclude_null_checks"] == "book_alias"
+        assert not ups._control.get_table_spec("genres")["exclude_null_checks"]
+
+    def test_invalid_table_rejected_at_construction(self, db):
+        with pytest.raises(ValueError, match="not in the configured tables"):
+            self._make(db, exclude_cols_by_table={"not_a_table": ["x"]})


### PR DESCRIPTION
## Summary

Brings configuration-file support to the `PgUpsert` constructor (previously CLI-only) and builds two capabilities on top of it. A single `pg_upsert.config` module is now the one source of truth for config-key handling, consumed by both the CLI and the library so they can't drift.

- **`PgUpsert.from_config()`** — construct directly from the same YAML file the CLI's `--config-file` accepts (a path *or* a dict). Both CLI-style keys (`exclude_columns`, `commit`, …) and native constructor names (`exclude_cols`, `do_commit`, …) work; unknown keys are ignored. Connection parts (`host`/`port`/`database`/`user`) are assembled into a URI; the password is prompted (or read from `PGPASSWORD`) at connect time. `**overrides` (including non-YAML values like `conn`/`callback`) win over the file.
- **Layered config sources** — `from_config()` also accepts an ordered `list`/`tuple` of sources, shallow-merged left-to-right (later wins, key-by-key replacement — no deep merge), with `**overrides` beating every file. Merging happens on the raw, alias-canonicalized config, so connection parts merge before the URI is built and `commit`/`do_commit` collapse across files. Lets a large shared config + small task-specific overrides coexist.
- **Per-table column excludes** — new `exclude_cols_by_table` / `exclude_null_check_cols_by_table` parameters (config keys `exclude_columns_by_table` / `null_columns_by_table`) map a table to its own column list, **merged on top of** the global lists for that table. The `ups_control` schema is unchanged.

## Compatibility

Additive only — all new constructor parameters are optional and default to prior behavior. The `ups_control` schema and the execsql2-guarded API surface (`PgUpsert(conn=…)`, `qa_all()`/`upsert_all()`/`run()`/`commit()`, `qa_passed`) are untouched.

## Tests & docs

- Full suite: **436 passed**, coverage **92.25%** (floor 90%); `ruff check` clean.
- New pure-logic + live-DB tests for config loading/merging, per-table merge/validation.
- Updated `docs/examples.md` (from_config, layering, per-table), `docs/qa_checks.md`, constructor docstrings (API ref), and `pg-upsert.example.yaml`.

## Follow-ups (not in this PR)

- CLI repeatable `--config-file` and a tsconfig-style `extends:` key for layering on the CLI side.
- Revisit whether columns in `exclude_cols` should still be subject to all QA checks except column-existence (current, intentional behavior) — flagged during review.

Closes #14
Closes #30